### PR TITLE
Fix the multidamage

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -717,10 +717,10 @@ impl Game {
         let (mut player_dmg, mut player_health) = (&mut player_dmg, &mut health).get(self.player)
             .unwrap();
 
-        if matches!(&*player_dmg, PlayerDamageState::Cooldown(_)) { return; }
-        if player_health.0 <= 0 { return; }
-
         for (_, brute_rb, brute_pos, brute_state) in (&brute, &rbs, &pos, &state).iter() {
+            if matches!(&*player_dmg, PlayerDamageState::Cooldown(_)) { return; }
+            if player_health.0 <= 0 { return; }
+
             if !matches!(brute_state, EnemyState::Free) { continue; }
             let Some(collision) = phys.any_collisions(
                 *brute_pos,


### PR DESCRIPTION
Closes #60 

The bug happened, because the `brute_damage` system applied all collision damages that happened in a single frame.