### PR TITLE
Rework the CI and deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+levels/
+.git/
+.github/
+LICENSE
+README.MD
+.gitignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,50 +8,35 @@ env:
 jobs:
   ci-check:
     runs-on: ubuntu-latest
+    container: rust:1.88.0-bookworm 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ vars.RUST_VERSION }}
-          override: true
-          target: wasm32-unknown-unknown
-          components: rustfmt
+      - uses: actions/checkout@v5
       - uses: actions/cache@v4
         continue-on-error: false
         with:
           path: |
             ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ~/.cargo/registry/
+            ~/.cargo/git/
             target/
-          key: ci-${{ runner.os }}-${{ vars.RUST_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ci-${{ runner.os }}-${{ vars.RUST_VERSION }}-cargo-
+          key: ci-bookworm-1.88-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ci-bookworm-1.88-cargo-
       - shell: bash
         run: >
-          sudo apt-get update &&
-          sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+          apt-get update &&
+          apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev &&
+          rustup target add wasm32-unknown-unknown &&
+          rustup component add rustfmt
       - name: Check everything for desktop
-        run: cargo check --locked --all-targets
+        run: cargo build --locked --all-targets
       - name: Check WASM
-        run: cargo check --locked --target wasm32-unknown-unknown
+        run: cargo build --locked --target wasm32-unknown-unknown
       - name: Run tests
         run: cargo test --workspace --package "*" --exclude quad-jam-2024 --locked
-  code-audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: List FIXME
-        run: grep -Iirn "FIXME" . --exclude-dir .github --exclude-dir target --exclude-dir assets --exclude "*.lock" --exclude-dir static --exclude-dir .git
-  cargo-fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ vars.RUST_VERSION }}
-          override: true
-          components: rustfmt
       - run: cargo fmt --all -- --check
+  deploy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build image
+        run: docker build -t quad-jam .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,56 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ vars.RUST_VERSION }}
-          target: wasm32-unknown-unknown
-          components: rustfmt
-      - name: Set up cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: deploy-${{ runner.os }}-${{ vars.RUST_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: deploy-${{ runner.os }}-${{ vars.RUST_VERSION }}-cargo-
-      - name: Build level-compiler
-        run: cargo build -p lib-level
-      - name: Build
-        run: cargo build --target wasm32-unknown-unknown --profile wasm-release --locked
-      - name: Create dist dir
-        run: mkdir dist
-      - name: Create levels dir
-        run: mkdir ./dist/levels
-      - name: Build all maps
-        run: ./target/debug/lib-level --assets ./assets compile-dir -d ./tiled-project -o ./dist/levels
-      - name: Acquire wasm build
-        run: cp ./target/wasm32-unknown-unknown/wasm-release/${{ github.event.repository.name }}.wasm ./dist/game.wasm
-      - name: Copy assets
-        run: cp -rf ./assets ./dist/
-      - name: Copy static
-        run: cp ./static/* ./dist
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: web-dist
-          path: ./dist
-  deploy-to-pages:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Create artifact dir
-        run: mkdir ./dist
-      - name: Acquire artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: web-dist
-          path: ./dist
+        uses: actions/checkout@v5
+      - name: Build image
+        run: docker build -t quad-jam .
+      - name: Instantiate image
+        run: docker create --name quad-jam quad-jam
+      - name: Extract artifact
+        run: docker cp quad-jam:/usr/local/apache2/htdocs/ ./dist
       - name: Push to GitHub pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/itch.yml
+++ b/.github/workflows/itch.yml
@@ -9,56 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ vars.RUST_VERSION }}
-          target: wasm32-unknown-unknown
-          components: rustfmt
-      - name: Set up cargo cache
-        uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: deploy-${{ runner.os }}-${{ vars.RUST_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: deploy-${{ runner.os }}-${{ vars.RUST_VERSION }}-cargo-
-      - name: Build level-compiler
-        run: cargo build -p lib-level
-      - name: Build
-        run: cargo build --target wasm32-unknown-unknown --profile wasm-release --locked
-      - name: Create dist dir
-        run: mkdir dist
-      - name: Create levels dir
-        run: mkdir ./dist/levels
-      - name: Build all maps
-        run: ./target/debug/lib-level --assets ./assets compile-dir -d ./tiled-project -o ./dist/levels
-      - name: Acquire wasm build
-        run: cp ./target/wasm32-unknown-unknown/wasm-release/${{ github.event.repository.name }}.wasm ./dist/game.wasm
-      - name: Copy assets
-        run: cp -rf ./assets ./dist/
-      - name: Copy static
-        run: cp ./static/* ./dist
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: web-dist
-          path: ./dist
-  deploy-to-itch:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Create artifact dir
-        run: mkdir ./dist
-      - name: Acquire artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: web-dist
-          path: ./dist
+        uses: actions/checkout@v5
+      - name: Build image
+        run: docker build -t quad-jam .
+      - name: Instantiate image
+        run: docker create --name quad-jam quad-jam
+      - name: Extract artifact
+        run: docker cp quad-jam:/usr/local/apache2/htdocs/ ./dist 
       - name: Push HTML5 version to itch.io
         uses: manleydev/butler-publish-itchio-action@v1.0.3
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM rust:1.88.0-bookworm AS build
+
+# Setup env
+RUN <<EOF
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        libasound2-dev \
+        libudev-dev \
+        libwayland-dev \
+        libxkbcommon-dev
+    rustup target add wasm32-unknown-unknown
+EOF
+ADD . /project/
+RUN <<EOF
+    cd /project &&\
+    cargo build --locked --package lib-level &&\
+    cargo build --target wasm32-unknown-unknown --profile wasm-release --locked
+EOF
+# Put all files
+COPY /assets/ /dist/assets
+COPY /static/* /dist
+RUN cp /project/target/wasm32-unknown-unknown/wasm-release/quad-jam-2024.wasm /dist/game.wasm
+RUN mkdir /dist/levels && \
+    /project/target/debug/lib-level \
+        --assets /project/assets \ 
+        compile-dir \
+            -d /project/tiled-project \
+            -o /dist/levels
+
+FROM httpd:trixie 
+COPY --from=build /dist /usr/local/apache2/htdocs/ 

--- a/README.MD
+++ b/README.MD
@@ -12,80 +12,32 @@ It is in active development.
 * F11 -- toggle fullscreen
 * Escape -- pause
 
-## Building Manually
+## Building For Deploy
 
-Please note the following:
-* The desktop build is for development only. The user-ready build
-is the WASM one.
-* The Linux desktop build should work, but is not tested against all
-possible configurations.
-* THe MacOS desktop build should work, but is not tested.
+1. Make sure you have docker installed (minimal version: `28.2.2`)
+2. Clone this repository
+3. Run `docker build -t quad-jam .` in the repository root
+4. Run `docker run --rm -p 8080:80 --name quad-jam quad-jam`
+    * NOTE: the command will hang. This is intentional. Pressing Ctrl+C will
+      stop the game
+5. You can now play the game by going to `localhost:8080` in your browser of choice
+6. To stop the game just go back to the terminal and press Ctrl+C
 
-### For Desktop (dev build)
+## Building For Development
 
 1. Make sure you have the reqiured dependencies.
     * (For Linux) make sure you have the development packages of the following libraries installed: `asound2, udev, wayland, xkbcommon`.
     * (For Windows) make sure you have Windows SDK installed.
-
 2. Make sure you have Rust version 1.88.0 or higher.
-
 3. Make sure you have Cargo version 1.88.0 or higher.
-
 4. Run the following command in project root.
 ```
 cargo build
 ```
-
 5. To run the dev build, execute the following ocmmand in project root.
 ```
 cargo run
 ```
-
-### For WASM (deploy build)
-
-1. Make sure you have the `wasm32-unknown-unknown` target installed.
-
-2. Create the `dist` directory in project root.
-```
-mkdir dist
-```
-
-3. Create the `levels` inside `dist`
-```
-mkdir dist/levels
-```
-
-4. Build lib-level for desktop.
-```
-cargo build -p lib-level
-```
-
-4. Build all maps. 
-```
-./target/debug/lib-level --assets ./assets compile-dir -d ./tiled_project -o ./dist/levels
-```
-
-5. Build the game under the wasm release profile for wasm.
-```
-cargo build --target wasm32-unknown-unknown --profile wasm-release --locked
-```
-
-6. Put the build into the `dist` folder calling it `game.wasm`
-```
-cp ./target/wasm32-unknown-unknown/wasm-release/quad-jam-2024.wasm ./dist/game.wasm
-```
-
-7. Copy the `assets` folder into `dist` 
-```
-cp -rf ./assets ./dist/
-```
-
-8. Copy the **contents** of `static` folder into `dist` 
-```
-cp ./static/* ./dist
-```
-
-9. You can now deploy the game. The `dist` directory has everything you need.
 
 ## Working With The Project
 

--- a/lib-level/src/main.rs
+++ b/lib-level/src/main.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::str::FromStr;
 use std::{path::PathBuf, process::ExitCode};
 
+use anyhow::Context;
 use clap::{Parser, Subcommand};
 
 fn main() -> ExitCode {
@@ -36,9 +37,9 @@ fn check_map(assets_directory: PathBuf, map: PathBuf) -> anyhow::Result<()> {
 fn compile_map(assets_directory: &PathBuf, map: PathBuf, out: PathBuf) -> anyhow::Result<()> {
     println!("Compiling {map:?} into {out:?}");
 
-    let level = lib_level::tiled_load::load_level(assets_directory, map)?;
-    let out = fs::File::create(out)?;
-    lib_level::binary_io::compile::write_level(&level, out)
+    let level = lib_level::tiled_load::load_level(assets_directory, map).context("loading map")?;
+    let out = fs::File::create(out).context("opening the output")?;
+    lib_level::binary_io::compile::write_level(&level, out).context("writing the level")
 }
 
 fn dump_map(map: PathBuf) -> anyhow::Result<()> {


### PR DESCRIPTION
When something changes about the project structure (new subdir is added or something gets renamed, new sub-project, etc.), there is a high risk of breaking the deployment pipeline. It is near impossible to test the pipeline locally. In addition, the deployment scripts are oversized copy-paste. Let's just put all actions into Docker.

* Closes #178 
* Closes #109 