### PR TITLE
lib-game: rework animation repr

### DIFF
--- a/lib-game/src/animation/actions.rs
+++ b/lib-game/src/animation/actions.rs
@@ -4,11 +4,12 @@ use lib_asset::AssetContainer;
 use lib_asset::{AssetKey, level::CharacterInfo};
 use macroquad::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::any::TypeId;
 
 use crate::Resources;
 
 pub trait ClipAction: std::fmt::Debug + Default + Copy + 'static {
+    const ACTION_KIND: u32;
+
     fn manifest_key() -> &'static str;
 
     fn global_offset(&mut self, _off: Vec2) {}
@@ -23,19 +24,12 @@ pub trait ClipAction: std::fmt::Debug + Default + Copy + 'static {
     fn to_manifest(&self, resources: &Resources) -> serde_json::Value;
 }
 
-pub const CLIP_TYPES: [TypeId; 6] = [
-    TypeId::of::<Invulnerability>(),
-    TypeId::of::<Move>(),
-    TypeId::of::<DrawSprite>(),
-    TypeId::of::<AttackBox>(),
-    TypeId::of::<LockInput>(),
-    TypeId::of::<Spawn>(),
-];
-
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Invulnerability;
 
 impl ClipAction for Invulnerability {
+    const ACTION_KIND: u32 = 0;
+
     fn manifest_key() -> &'static str {
         "invulnerability"
     }
@@ -53,6 +47,8 @@ impl ClipAction for Invulnerability {
 pub struct Move;
 
 impl ClipAction for Move {
+    const ACTION_KIND: u32 = 1;
+
     fn manifest_key() -> &'static str {
         "move"
     }
@@ -79,6 +75,8 @@ pub struct DrawSprite {
 }
 
 impl ClipAction for DrawSprite {
+    const ACTION_KIND: u32 = 2;
+
     fn global_offset(&mut self, off: Vec2) {
         self.local_pos += off;
     }
@@ -175,6 +173,8 @@ pub struct AttackBox {
 }
 
 impl ClipAction for AttackBox {
+    const ACTION_KIND: u32 = 3;
+
     fn global_offset(&mut self, off: Vec2) {
         self.local_pos += off;
     }
@@ -224,6 +224,8 @@ pub struct LockInput {
 }
 
 impl ClipAction for LockInput {
+    const ACTION_KIND: u32 = 4;
+
     #[cfg(feature = "dev-env")]
     fn editor_ui(&mut self, _resources: &AssetContainer<Texture2D>, ui: &mut egui::Ui) {
         ui.checkbox(&mut self.allow_walk_input, "allow walk input");
@@ -253,6 +255,8 @@ pub struct Spawn {
 }
 
 impl ClipAction for Spawn {
+    const ACTION_KIND: u32 = 5;
+
     fn global_offset(&mut self, off: Vec2) {
         self.local_pos += off;
     }

--- a/lib-game/src/animation/container.rs
+++ b/lib-game/src/animation/container.rs
@@ -1,15 +1,16 @@
 use anyhow::Context;
-use hashbrown::HashMap;
 #[cfg(feature = "dev-env")]
 use lib_asset::AssetContainer;
 use macroquad::prelude::*;
-use std::any::{Any, TypeId, type_name};
+use std::any::{Any, type_name};
 
 use crate::Resources;
 
 use super::actions::*;
 
 pub trait AnimContainer: std::fmt::Debug + Any {
+    fn action_kind(&self) -> u32;
+
     fn clip_count(&self) -> u32;
     fn get_clip(&self, clip_id: u32) -> Option<Clip>;
     #[cfg(feature = "dev-env")]
@@ -45,21 +46,21 @@ pub trait AnimContainer: std::fmt::Debug + Any {
     fn max_pos(&self) -> u32;
 
     fn to_manifest(&self, resources: &Resources) -> lib_asset::animation_manifest::Clips;
-    fn from_manifest(
-        resources: &Resources,
-        generic: &lib_asset::animation_manifest::Clips,
-    ) -> anyhow::Result<Box<dyn AnimContainer>>
-    where
-        Self: Sized;
 }
 
 #[derive(Default, Debug)]
 pub struct Animation {
     pub is_looping: bool,
-    pub action_tracks: HashMap<TypeId, Box<dyn AnimContainer>>,
+
+    pub invulerability: Clips<Invulnerability>,
+    pub mov: Clips<Move>,
+    pub draw_sprite: Clips<DrawSprite>,
+    pub attack_box: Clips<AttackBox>,
+    pub lock_input: Clips<LockInput>,
+    pub spawn: Clips<Spawn>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct Clips<T> {
     pub clips: Vec<(Clip, T)>,
     pub tracks: Vec<Track>,
@@ -70,7 +71,7 @@ pub struct Track {
     pub name: String,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Clip {
     pub track_id: u32,
     pub start: u32,
@@ -89,8 +90,8 @@ impl Clip {
 
 impl Animation {
     pub fn max_pos(&self) -> u32 {
-        self.action_tracks
-            .values()
+        self.all_containers()
+            .into_iter()
             .map(|x| x.max_pos())
             .max()
             .unwrap_or_default()
@@ -100,8 +101,8 @@ impl Animation {
         lib_asset::animation_manifest::Animation {
             is_looping: self.is_looping,
             action_tracks: self
-                .action_tracks
-                .values()
+                .all_containers()
+                .into_iter()
                 .map(|container| {
                     (
                         container.manifest_key().to_string(),
@@ -116,80 +117,131 @@ impl Animation {
         resources: &Resources,
         manifest: &lib_asset::animation_manifest::Animation,
     ) -> anyhow::Result<Self> {
-        let mut action_tracks = HashMap::new();
-
-        Self::add_action_track::<Invulnerability>(resources, &mut action_tracks, manifest)?;
-        Self::add_action_track::<Move>(resources, &mut action_tracks, manifest)?;
-        Self::add_action_track::<DrawSprite>(resources, &mut action_tracks, manifest)?;
-        Self::add_action_track::<AttackBox>(resources, &mut action_tracks, manifest)?;
-        Self::add_action_track::<LockInput>(resources, &mut action_tracks, manifest)?;
-        Self::add_action_track::<Spawn>(resources, &mut action_tracks, manifest)?;
-        debug_assert_eq!(
-            action_tracks.len(),
-            CLIP_TYPES.len(),
-            "incomplete maninfest"
-        );
         Ok(Animation {
             is_looping: manifest.is_looping,
-            action_tracks,
+            invulerability: Self::parse_clips(resources, manifest)?,
+            mov: Self::parse_clips(resources, manifest)?,
+            draw_sprite: Self::parse_clips(resources, manifest)?,
+            attack_box: Self::parse_clips(resources, manifest)?,
+            lock_input: Self::parse_clips(resources, manifest)?,
+            spawn: Self::parse_clips(resources, manifest)?,
         })
     }
 
-    fn add_action_track<T: ClipAction>(
+    pub fn all_inactive_clips(&self, pos: u32) -> impl Iterator<Item = (u32, u32)> {
+        self.all_containers()
+            .into_iter()
+            .flat_map(move |container| {
+                let elem_id = container.action_kind();
+                (0..container.clip_count()).filter_map(move |clip_id| {
+                    let clip = container.get_clip(clip_id).unwrap();
+                    if clip.contains_pos(pos) {
+                        None
+                    } else {
+                        Some((elem_id, clip_id))
+                    }
+                })
+            })
+    }
+
+    pub fn all_containers(&self) -> [&'_ dyn AnimContainer; 6] {
+        [
+            &self.invulerability as &dyn AnimContainer,
+            &self.mov as &dyn AnimContainer,
+            &self.draw_sprite as &dyn AnimContainer,
+            &self.attack_box as &dyn AnimContainer,
+            &self.lock_input as &dyn AnimContainer,
+            &self.spawn as &dyn AnimContainer,
+        ]
+    }
+
+    pub fn all_containers_mut<'a>(&mut self) -> [&'_ mut dyn AnimContainer; 6] {
+        [
+            &mut self.invulerability as &mut dyn AnimContainer,
+            &mut self.mov as &mut dyn AnimContainer,
+            &mut self.draw_sprite as &mut dyn AnimContainer,
+            &mut self.attack_box as &mut dyn AnimContainer,
+            &mut self.lock_input as &mut dyn AnimContainer,
+            &mut self.spawn as &mut dyn AnimContainer,
+        ]
+    }
+
+    pub fn get_container(&self, kind: u32) -> &'_ dyn AnimContainer {
+        let all_containers = self.all_containers();
+        assert!(
+            (kind as usize) < all_containers.len(),
+            "Invalid kind: {kind}"
+        );
+        self.all_containers()[kind as usize]
+    }
+
+    pub fn get_container_mut(&mut self, kind: u32) -> &'_ mut dyn AnimContainer {
+        let all_containers = self.all_containers_mut();
+        assert!(
+            (kind as usize) < all_containers.len(),
+            "Invalid kind: {kind}"
+        );
+        self.all_containers_mut()[kind as usize]
+    }
+
+    fn parse_clips<T: ClipAction>(
         resources: &Resources,
-        action_tracks: &mut HashMap<TypeId, Box<dyn AnimContainer>>,
         manifest: &lib_asset::animation_manifest::Animation,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Clips<T>> {
         let manifest_key = T::manifest_key();
         let Some(entry) = manifest.action_tracks.get(manifest_key) else {
             anyhow::bail!("No such action track: {manifest_key:?}");
         };
-        let clips = Clips::<T>::from_manifest(resources, entry)?;
-        action_tracks.insert(TypeId::of::<T>(), clips);
-        Ok(())
-    }
 
-    pub fn active_clips<T: ClipAction>(&self, pos: u32) -> impl Iterator<Item = (u32, T)> {
-        self.action_track::<T>()
-            .clips
+        Clips::<T>::from_manifest(resources, entry)
+    }
+}
+
+impl<T> Clips<T> {
+    pub fn active_clips(&self, pos: u32) -> impl Iterator<Item = (u32, &T)> {
+        self.clips
             .iter()
-            .copied()
             .enumerate()
             .filter(move |(_, (x, _))| x.contains_pos(pos))
             .map(|(idx, (_, action))| (idx as u32, action))
     }
 
-    pub fn inactive_clips<T: ClipAction>(&self, pos: u32) -> impl Iterator<Item = (u32, T)> {
-        self.action_track::<T>()
-            .clips
+    pub fn inactive_clips(&self, pos: u32) -> impl Iterator<Item = (u32, &T)> {
+        self.clips
             .iter()
-            .copied()
             .enumerate()
             .filter(move |(_, (x, _))| !x.contains_pos(pos))
             .map(|(idx, (_, action))| (idx as u32, action))
     }
+}
 
-    pub fn all_inactive_clips(&self, pos: u32) -> impl Iterator<Item = (TypeId, u32)> {
-        CLIP_TYPES.into_iter().flat_map(move |kind| {
-            let container = &self.action_tracks[&kind];
-            (0..container.clip_count()).filter_map(move |clip_id| {
-                let clip = container.get_clip(clip_id).unwrap();
-                if clip.contains_pos(pos) {
-                    None
-                } else {
-                    Some((kind, clip_id))
-                }
-            })
-        })
-    }
-
-    pub fn action_track<T: ClipAction>(&self) -> &Clips<T> {
-        let container = &self.action_tracks[&TypeId::of::<T>()];
-        let container: &dyn AnimContainer = container.as_ref();
-        match (container as &dyn Any).downcast_ref::<Clips<T>>() {
-            Some(x) => x,
-            None => panic!("Type mismatch"),
+impl<T: ClipAction> Clips<T> {
+    fn from_manifest(
+        resources: &Resources,
+        generic: &lib_asset::animation_manifest::Clips,
+    ) -> anyhow::Result<Self> {
+        let mut tracks = Vec::new();
+        for track in &generic.tracks {
+            tracks.push(Track {
+                name: track.name.clone(),
+            });
         }
+
+        let mut clips = Vec::new();
+        for (clip_id, clip) in generic.clips.iter().enumerate() {
+            let action = T::from_manifest(resources, &clip.action)
+                .with_context(|| format!("clip {clip_id}"))?;
+            clips.push((
+                Clip {
+                    track_id: clip.track_id,
+                    start: clip.start,
+                    len: clip.len,
+                },
+                action,
+            ));
+        }
+
+        Ok(Self { clips, tracks })
     }
 }
 
@@ -332,37 +384,6 @@ impl<T: ClipAction> AnimContainer for Clips<T> {
         self.tracks.get(track_id as usize)
     }
 
-    fn from_manifest(
-        resources: &Resources,
-        generic: &lib_asset::animation_manifest::Clips,
-    ) -> anyhow::Result<Box<dyn AnimContainer>>
-    where
-        Self: Sized,
-    {
-        let mut tracks = Vec::new();
-        for track in &generic.tracks {
-            tracks.push(Track {
-                name: track.name.clone(),
-            });
-        }
-
-        let mut clips = Vec::new();
-        for (clip_id, clip) in generic.clips.iter().enumerate() {
-            let action = T::from_manifest(resources, &clip.action)
-                .with_context(|| format!("clip {clip_id}"))?;
-            clips.push((
-                Clip {
-                    track_id: clip.track_id,
-                    start: clip.start,
-                    len: clip.len,
-                },
-                action,
-            ));
-        }
-
-        Ok(Box::new(Self { clips, tracks }))
-    }
-
     fn to_manifest(&self, resources: &Resources) -> lib_asset::animation_manifest::Clips {
         let tracks = self
             .tracks
@@ -401,6 +422,10 @@ impl<T: ClipAction> AnimContainer for Clips<T> {
     ) {
         self.clips[clip_id as usize].1.editor_ui(resources, ui);
     }
+
+    fn action_kind(&self) -> u32 {
+        T::ACTION_KIND
+    }
 }
 
 #[cfg(feature = "dev-env")]
@@ -408,108 +433,167 @@ impl Animation {
     pub fn clip_editor_ui(
         &mut self,
         resources: &AssetContainer<Texture2D>,
-        kind: TypeId,
+        kind: u32,
         clip_id: u32,
         ui: &mut egui::Ui,
     ) {
-        let Some(container) = self.action_tracks.get_mut(&kind) else {
-            return;
-        };
-        container.clip_action_editor_ui(resources, clip_id, ui);
+        self.get_container_mut(kind)
+            .clip_action_editor_ui(resources, clip_id, ui);
     }
 
-    pub fn get_clip(&self, kind: TypeId, clip_id: u32) -> Option<Clip> {
-        let container = self.action_tracks.get(&kind)?;
-        container.get_clip(clip_id)
+    pub fn get_clip(&self, kind: u32, clip_id: u32) -> Option<Clip> {
+        self.get_container(kind).get_clip(clip_id)
     }
 
-    pub fn get_track(&self, kind: TypeId, track_id: u32) -> Option<&Track> {
-        let container = self.action_tracks.get(&kind)?;
-        container.get_track(track_id)
+    pub fn get_track(&self, kind: u32, track_id: u32) -> Option<&Track> {
+        self.get_container(kind).get_track(track_id)
     }
 
     pub fn global_offset(&mut self, off: Vec2) {
-        for container in self.action_tracks.values_mut() {
+        for container in self.all_containers_mut() {
             container.offset_clip_actions(off);
         }
     }
 
-    pub fn add_track(&mut self, kind: TypeId, name: String) {
-        let Some(container) = self.action_tracks.get_mut(&kind) else {
-            return;
-        };
-        container.add_track(name);
+    pub fn add_track(&mut self, kind: u32, name: String) {
+        self.get_container_mut(kind).add_track(name);
     }
 
-    pub fn delete_track(&mut self, kind: TypeId, track_id: u32) {
-        let Some(container) = self.action_tracks.get_mut(&kind) else {
-            return;
-        };
-        container.delete_track(track_id);
+    pub fn delete_track(&mut self, kind: u32, track_id: u32) {
+        self.get_container_mut(kind).delete_track(track_id);
     }
 
-    pub fn add_clip(&mut self, kind: TypeId, track_id: u32, start: u32, len: u32) {
-        let Some(container) = self.action_tracks.get_mut(&kind) else {
-            return;
-        };
-        container.add_clip(track_id, start, len);
+    pub fn add_clip(&mut self, kind: u32, track_id: u32, start: u32, len: u32) {
+        self.get_container_mut(kind).add_clip(track_id, start, len);
     }
 
-    pub fn delete_clip(&mut self, kind: TypeId, clip_id: u32) {
-        let Some(container) = self.action_tracks.get_mut(&kind) else {
-            return;
-        };
-        container.delete_clip(clip_id);
+    pub fn delete_clip(&mut self, kind: u32, clip_id: u32) {
+        self.get_container_mut(kind).delete_clip(clip_id);
     }
 
     pub fn set_clip_pos_len(
         &mut self,
-        kind: TypeId,
+        kind: u32,
         idx: u32,
         new_track: u32,
         new_pos: u32,
         new_len: u32,
     ) {
-        let Some(container) = self.action_tracks.get_mut(&kind) else {
-            return;
-        };
-        container.set_clip_pos_len(idx, new_track, new_pos, new_len);
+        self.get_container_mut(kind)
+            .set_clip_pos_len(idx, new_track, new_pos, new_len);
     }
 
-    pub fn all_clips(&self) -> impl Iterator<Item = (TypeId, &str, u32, u32, Clip)> {
-        CLIP_TYPES
+    pub fn all_clips(&self) -> impl Iterator<Item = (u32, &str, u32, u32, Clip)> {
+        let mut kind_offset = 0;
+        self.all_containers()
             .into_iter()
-            .zip(self.all_track_ofsets())
-            .flat_map(|(kind, y_off)| {
-                let container = &self.action_tracks[&kind];
+            .flat_map(move |container| {
+                let kind = container.action_kind();
+                let curr_kind_offset = kind_offset;
                 let name = container.manifest_key();
+                kind_offset += container.track_count();
                 (0..container.clip_count()).map(move |clip_id| {
                     let clip = container.get_clip(clip_id).unwrap();
-                    (kind, name, clip_id, y_off + clip.track_id, clip)
+                    (kind, name, clip_id, curr_kind_offset + clip.track_id, clip)
                 })
             })
     }
 
-    pub fn all_tracks(&self) -> impl Iterator<Item = (TypeId, u32, u32, &Track)> {
-        CLIP_TYPES
+    pub fn all_tracks(&self) -> impl Iterator<Item = (u32, u32, u32, &Track)> {
+        let mut kind_offset = 0;
+        self.all_containers()
             .into_iter()
-            .zip(self.all_track_ofsets())
-            .flat_map(|(kind, y_off)| {
-                let container = &self.action_tracks[&kind];
+            .flat_map(move |container| {
+                let kind = container.action_kind();
+                let curr_kind_offset = kind_offset;
+                kind_offset += container.track_count();
                 (0..container.track_count()).map(move |track_id| {
                     let track = container.get_track(track_id).unwrap();
-                    (kind, track_id, track_id + y_off, track)
+                    (kind, track_id, curr_kind_offset + track_id, track)
                 })
             })
     }
+}
 
-    fn all_track_ofsets(&self) -> [u32; CLIP_TYPES.len()] {
-        let mut track_offsets = [0; CLIP_TYPES.len()];
-        let mut curr_off = 0;
-        for (kind, off) in CLIP_TYPES.into_iter().zip(&mut track_offsets) {
-            *off = curr_off;
-            curr_off += self.action_tracks[&kind].track_count();
+#[cfg(test)]
+mod tests {
+    use hashbrown::HashSet;
+
+    use crate::{AnimContainer, Clip, ClipAction, DrawSprite, animation::container::Animation};
+
+    #[test]
+    fn container_lookup_consistent() {
+        let mut anim = Animation::default();
+
+        let kinds = anim.all_containers().map(|x| x.action_kind());
+        for kind in kinds {
+            assert_eq!(anim.get_container(kind).action_kind(), kind);
         }
-        track_offsets
+
+        let kinds = anim.all_containers_mut().map(|x| x.action_kind());
+        for kind in kinds {
+            assert_eq!(anim.get_container_mut(kind).action_kind(), kind);
+        }
+    }
+
+    #[test]
+    fn all_tracks_y_contigious_basic() {
+        let mut anim = Animation::default();
+        anim.all_containers_mut()
+            .into_iter()
+            .for_each(|x| x.add_track("test1".to_string()));
+
+        let mut tracks = anim.all_tracks().map(|x| x.2).collect::<Vec<_>>();
+        tracks.sort();
+
+        assert_eq!(tracks, (0..tracks.len() as u32).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn all_tracks_y_contigious_dup() {
+        let mut anim = Animation::default();
+        anim.all_containers_mut()
+            .into_iter()
+            .for_each(|x| x.add_track("test1".to_string()));
+        anim.draw_sprite.add_track("test2".to_string());
+
+        let mut tracks = anim.all_tracks().map(|x| x.2).collect::<Vec<_>>();
+        tracks.sort();
+
+        assert_eq!(tracks, (0..tracks.len() as u32).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn clip_kinds_unique() {
+        let anim = Animation::default();
+        let container_kinds = anim
+            .all_containers()
+            .into_iter()
+            .map(|x| x.action_kind())
+            .collect::<HashSet<_>>();
+        let container_count = anim.all_containers().into_iter().count();
+
+        assert_eq!(container_kinds.len(), container_count);
+    }
+
+    #[test]
+    fn all_clips_basic() {
+        let mut anim = Animation::default();
+        anim.draw_sprite.add_track("test1".to_string());
+        anim.draw_sprite.add_track("test2".to_string());
+        anim.draw_sprite.add_clip(0, 0, 1);
+        let clips = anim.all_clips().collect::<Vec<_>>();
+        let expected = [(
+            DrawSprite::ACTION_KIND,
+            DrawSprite::manifest_key(),
+            0,
+            0,
+            Clip {
+                track_id: 0,
+                start: 0,
+                len: 1,
+            },
+        )];
+        assert_eq!(clips.as_slice(), expected.as_slice());
     }
 }

--- a/lib-game/src/animation/mod.rs
+++ b/lib-game/src/animation/mod.rs
@@ -1,8 +1,6 @@
 mod actions;
 mod container;
 
-use std::any::TypeId;
-
 use hashbrown::HashMap;
 use hecs::{CommandBuffer, Entity, EntityBuilder, World};
 use lib_asset::level::CharacterDef;
@@ -98,13 +96,14 @@ pub(crate) fn update_attack_boxes(
     for_each_character::<()>(world, resources, |parent, character| {
         for (clip_id, attack) in character
             .animation
-            .active_clips::<AttackBox>(character.anim_cursor())
+            .attack_box
+            .active_clips(character.anim_cursor())
         {
             let event = ClipActionObject {
                 parent,
                 animation: character.animation_id(),
                 clip_id,
-                kind: TypeId::of::<AttackBox>(),
+                kind: AttackBox::ACTION_KIND,
             };
             let new_col_tf = character.transform_child(
                 attack.rotate_with_parent,
@@ -150,13 +149,14 @@ pub(crate) fn update_spawned<G: Game>(
     for_each_character::<()>(world, resources, |parent, character| {
         for (clip_id, spawn) in character
             .animation
-            .active_clips::<Spawn>(character.anim_cursor())
+            .spawn
+            .active_clips(character.anim_cursor())
         {
             let event = ClipActionObject {
                 parent,
                 animation: character.animation_id(),
                 clip_id,
-                kind: TypeId::of::<Spawn>(),
+                kind: Spawn::ACTION_KIND,
             };
             let (pos, look_angle) = character.transform_character(
                 spawn.rotate_with_parent,
@@ -189,7 +189,8 @@ pub(crate) fn update_invulnerability(world: &mut World, resources: &Resources) {
     for_each_character::<()>(world, resources, |_, character| {
         let is_invulnerable = character
             .animation
-            .active_clips::<Invulnerability>(character.anim_cursor())
+            .invulerability
+            .active_clips(character.anim_cursor())
             .next()
             .is_some();
         character.character_q.hp.is_invulnerable = is_invulnerable;
@@ -205,13 +206,14 @@ pub(crate) fn update_draw_sprites(
     for_each_character::<()>(world, resources, |parent, character| {
         for (clip_id, draw_sprite) in character
             .animation
-            .active_clips::<DrawSprite>(character.anim_cursor())
+            .draw_sprite
+            .active_clips(character.anim_cursor())
         {
             let event = ClipActionObject {
                 parent,
                 animation: character.animation_id(),
                 clip_id,
-                kind: TypeId::of::<DrawSprite>(),
+                kind: DrawSprite::ACTION_KIND,
             };
             let new_sprite_tf = character.transform_child(
                 draw_sprite.rotate_with_parent,

--- a/lib-game/src/character.rs
+++ b/lib-game/src/character.rs
@@ -1,4 +1,4 @@
-use crate::{LockInput, Move, animation::Animation};
+use crate::animation::Animation;
 use hecs::{Entity, EntityBuilder, Query, World};
 use lib_asset::animation_manifest::AnimationId;
 use lib_col::{Group, Shape};
@@ -128,7 +128,8 @@ impl<'a, T> Character<'a, T> {
 
     pub fn get_input_flags(&self) -> (bool, bool) {
         self.animation
-            .active_clips::<LockInput>(self.anim_cursor())
+            .lock_input
+            .active_clips(self.anim_cursor())
             .map(|(_, x)| (x.allow_walk_input, x.allow_look_input))
             .next()
             .unwrap_or((true, true))
@@ -136,7 +137,8 @@ impl<'a, T> Character<'a, T> {
 
     pub fn can_move(&self) -> bool {
         self.animation
-            .active_clips::<Move>(self.anim_cursor())
+            .mov
+            .active_clips(self.anim_cursor())
             .next()
             .is_some()
     }

--- a/lib-game/src/components.rs
+++ b/lib-game/src/components.rs
@@ -1,5 +1,3 @@
-use std::any::TypeId;
-
 use crate::animation::Animation;
 use hecs::Entity;
 use lib_asset::{AssetKey, animation_manifest::AnimationId};
@@ -118,7 +116,7 @@ impl AnimationPlay {
 pub struct ClipActionObject {
     pub parent: Entity,
     pub animation: AnimationId,
-    pub kind: TypeId,
+    pub kind: u32,
     pub clip_id: u32,
 }
 

--- a/lib-game/src/dbg/animation_edit/clips.rs
+++ b/lib-game/src/dbg/animation_edit/clips.rs
@@ -1,5 +1,3 @@
-use std::any::TypeId;
-
 use crate::animation::{Animation, Clip};
 use egui::{Color32, Painter, Pos2, Rect, Stroke, TextStyle, Ui, WidgetText, pos2, vec2};
 
@@ -143,7 +141,7 @@ impl<'a> ClipsUi<'a> {
         ui: &mut Ui,
         painter: &Painter,
         widget_rect: Rect,
-        selected_track: Option<(TypeId, u32)>,
+        selected_track: Option<(u32, u32)>,
     ) {
         for (track_kind, track_id, track_y, track) in self.0.all_tracks() {
             let top = widget_rect.top() + (track_y as f32) * CLIP_HEIGHT;
@@ -185,9 +183,14 @@ impl<'a> ClipsUi<'a> {
         painter: &Painter,
         timeline_rect: Rect,
         tf: TimelineTf,
-        selected_clip: Option<(TypeId, u32)>,
+        selected_clip: Option<(u32, u32)>,
     ) {
+        let mut m = 0;
         for (clip_kind, clip_name, clip_id, clip_y, clip) in self.0.all_clips() {
+            if selected_clip == Some((clip_kind, clip_id)) {
+                m += 1;
+                log::info!("Selected: y={clip_y} id={clip_id} m={m}");
+            }
             ClipWidget(clip).paint(
                 ui,
                 painter,

--- a/lib-game/src/dbg/animation_edit/mod.rs
+++ b/lib-game/src/dbg/animation_edit/mod.rs
@@ -2,8 +2,6 @@ mod clips;
 mod save_ui;
 mod sequencer;
 
-use std::any::TypeId;
-
 use egui::{Button, ComboBox, DragValue, Label, Modal, Response, WidgetText, vec2};
 use egui::{Ui, Widget};
 use macroquad::math::Vec2;
@@ -16,17 +14,17 @@ use save_ui::*;
 use sequencer::*;
 
 use crate::animation::Animation;
-use crate::{AnimationPlay, AttackBox, CLIP_TYPES, CharacterLook, Resources};
+use crate::{AnimationPlay, AttackBox, CharacterLook, ClipAction, Resources};
 
 pub struct AnimationEdit {
     pub playback: Entity,
     sequencer_state: SequencerState,
     tf: TimelineTf,
-    selected_clip: Option<(TypeId, u32)>,
-    selected_track: Option<(TypeId, u32)>,
+    selected_clip: Option<(u32, u32)>,
+    selected_track: Option<(u32, u32)>,
 
     open_track_creation_modal: bool,
-    track_kind: TypeId,
+    track_kind: u32,
     track_label: String,
 
     open_global_offset_modal: bool,
@@ -40,7 +38,7 @@ impl AnimationEdit {
             sequencer_state: SequencerState::Idle,
             selected_clip: None,
             selected_track: None,
-            track_kind: TypeId::of::<AttackBox>(),
+            track_kind: AttackBox::ACTION_KIND,
             tf: TimelineTf {
                 zoom: 1.0,
                 pan: 0.0,
@@ -168,13 +166,13 @@ impl AnimationEdit {
             ui.set_width(250.0);
             ui.heading("Create track");
             ui.text_edit_singleline(&mut self.track_label);
-            let action_track = &anim.action_tracks[&self.track_kind];
-            let current_text = action_track.manifest_key();
+            let current_text = anim.get_container_mut(self.track_kind).manifest_key();
             ComboBox::new("track-kind", current_text)
                 .selected_text(current_text)
                 .show_ui(ui, |ui| {
-                    for selected_value in CLIP_TYPES {
-                        let selected_text = anim.action_tracks[&selected_value].manifest_key();
+                    for container in anim.all_containers() {
+                        let selected_value = container.action_kind();
+                        let selected_text = container.manifest_key();
                         ui.selectable_value(&mut self.track_kind, selected_value, selected_text);
                     }
                 });
@@ -241,7 +239,7 @@ fn selected_clip_ui(
     ui: &mut Ui,
     resources: &AssetContainer<Texture2D>,
     anim: &mut Animation,
-    selected_clip: &mut Option<(TypeId, u32)>,
+    selected_clip: &mut Option<(u32, u32)>,
 ) {
     ui.group(|ui| {
         ui.set_min_size(vec2(200.0, 300.0));

--- a/lib-game/src/dbg/animation_edit/sequencer.rs
+++ b/lib-game/src/dbg/animation_edit/sequencer.rs
@@ -1,5 +1,3 @@
-use std::any::TypeId;
-
 use egui::{
     Color32, FontId, Key, Painter, Pos2, Rect, Response, Sense, Stroke, Ui, Vec2, Widget, pos2,
 };
@@ -14,8 +12,8 @@ pub const TIMELINE_HEADER_HEIGHT: f32 = 32.0;
 
 pub struct Sequencer<'a> {
     pub cursor_pos: &'a mut u32,
-    pub selected_clip: &'a mut Option<(TypeId, u32)>,
-    pub selected_track: &'a mut Option<(TypeId, u32)>,
+    pub selected_clip: &'a mut Option<(u32, u32)>,
+    pub selected_track: &'a mut Option<(u32, u32)>,
     pub anim: &'a mut Animation,
     pub state: &'a mut SequencerState,
     pub tf: &'a mut TimelineTf,
@@ -232,7 +230,7 @@ impl<'a> Sequencer<'a> {
         &mut self,
         ui: &mut Ui,
         response: &Response,
-        kind: TypeId,
+        kind: u32,
         clip_id: u32,
         start_pos_x: f32,
         start_pos_y: f32,
@@ -283,7 +281,7 @@ impl<'a> Sequencer<'a> {
         &mut self,
         ui: &mut Ui,
         response: &Response,
-        kind: TypeId,
+        kind: u32,
         clip_id: u32,
         start_left: f32,
         start_right: f32,
@@ -513,7 +511,7 @@ impl TimelineTf {
 pub enum SequencerState {
     Idle,
     MoveClip {
-        kind: TypeId,
+        kind: u32,
         clip_id: u32,
         start_pos_x: f32,
         start_pos_y: f32,
@@ -521,7 +519,7 @@ pub enum SequencerState {
         total_drag_delta_y: f32,
     },
     ResizeClip {
-        kind: TypeId,
+        kind: u32,
         clip_id: u32,
         start_left: f32,
         start_right: f32,


### PR DESCRIPTION
Current animation representation has several inefficiencies. It has extra indirections, extra allocations and also constant checks. This is because different track kinds are stored in a polymorphic map. This was a bad idea in retrospect, as the only place where it improved something was the editor code. This adresses all of it: it reduces the overhead and code of working with Animation without harming the editor code too much.

As an extra bonus, the action kinds now have stable ids.